### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ProfilePictureEditPopup.jsx
+++ b/src/components/ProfilePictureEditPopup.jsx
@@ -15,7 +15,12 @@ const ProfilePictureEditPopup = ({ user, close }) => {
     const file = e.target.files[0];
     if (file) {
       setIsImg(true);
-      setImgUrl(URL.createObjectURL(file));
+      const objectUrl = URL.createObjectURL(file);
+      if (isValidBlobUrl(objectUrl)) {
+        setImgUrl(objectUrl);
+      } else {
+        console.error("Invalid image URL");
+      }
     }
   };
   const Upload = () => {
@@ -103,4 +108,9 @@ const ProfilePictureEditPopup = ({ user, close }) => {
     </div>
   );
 };
+
+const isValidBlobUrl = (url) => {
+  return url.startsWith("blob:");
+};
+
 export default ProfilePictureEditPopup;


### PR DESCRIPTION
Fixes [https://github.com/krishan-07/LinkedIn-replica/security/code-scanning/3](https://github.com/krishan-07/LinkedIn-replica/security/code-scanning/3)

To fix the problem, we need to ensure that the `imgUrl` is properly validated before being used as the `src` attribute of the `img` tag. One way to do this is to check that the `imgUrl` is a valid blob URL. This can be done by creating a utility function to validate the URL.

1. Create a utility function to validate the blob URL.
2. Use this function in `ProfilePictureEditPopup` to validate `imgUrl` before passing it to `ProfileImg`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
